### PR TITLE
Bump Xcode version to 12.5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,13 +94,13 @@ jobs:
         run: find $PWD -type f \( -name 'WORKSPACE' -o -name '*.bzl' -o -name '*.bazel' \) | xargs bazel run buildifier -- -lint=fix && git diff --exit-code
       - name: Check docs
         run: bazelisk run docs && git diff --exit-code docs
-  xcodeproj_tests_xcode_12_2:
-    name: .xcodeproj Tests on Xcode 12.2
+  xcodeproj_tests_xcode_12_5_1:
+    name: .xcodeproj Tests on Xcode 12.5.1
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode 12.5.1
+        run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
       - name: Run tests
         run: ./tests/xcodeproj-tests.sh --clean
   multi_arch_support:

--- a/.github/workflows/xcode_select.sh
+++ b/.github/workflows/xcode_select.sh
@@ -3,4 +3,4 @@ set -e
 echo "Selecting Xcode for environment"
 printenv
 sudo xcode-select -p
-sudo xcode-select -s /Applications/Xcode_12.2.app
+sudo xcode-select -s /Applications/Xcode_12.5.1.app


### PR DESCRIPTION
`macos-latest` runners have been updated to have Xcode 12.5.1 installed instead of Xcode 12.2.